### PR TITLE
Upgrade Quarkus 3.15.0 -> 3.32.3, Kotlin 2.1.0 -> 2.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.0</quarkus.version>
+    <quarkus.version>3.32.3</quarkus.version>
     <jimmer.version>0.9.120</jimmer.version>
     <central-publishing-maven-plugin.version>0.5.0</central-publishing-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
@@ -55,7 +55,7 @@
     <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-    <kotlin.version>2.1.0</kotlin.version>
+    <kotlin.version>2.3.20</kotlin.version>
   </properties>
 
   <dependencyManagement>

--- a/runtime/src/main/java/io/quarkiverse/jimmer/runtime/JimmerDataSourcesRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/jimmer/runtime/JimmerDataSourcesRecorder.java
@@ -14,7 +14,6 @@ import io.quarkiverse.jimmer.runtime.kotlin.QuarkusKSqlClientContainer;
 import io.quarkiverse.jimmer.runtime.kotlin.UnConfiguredDataSourceQuarkusKSqlClientContainer;
 import io.quarkiverse.jimmer.runtime.util.QuarkusSqlClientContainerUtil;
 import io.quarkus.agroal.runtime.DataSources;
-import io.quarkus.agroal.runtime.UnconfiguredDataSource;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -28,13 +27,6 @@ public class JimmerDataSourcesRecorder {
             DataSource dataSource;
             try {
                 dataSource = context.getInjectedReference(DataSources.class).getDataSource(dataSourceName);
-                if (dataSource instanceof UnconfiguredDataSource) {
-                    throw new ConfigurationException(String.format(Locale.ROOT,
-                            "Datasource '%s' is not configured."
-                                    + " To solve this, configure datasource '%s'."
-                                    + " Refer to https://quarkus.io/guides/datasource for guidance.",
-                            dataSourceName, dataSourceName));
-                }
             } catch (ConfigurationException e) {
                 return new UnConfiguredDataSourceQuarkusJSqlClientContainer(dataSourceName, String.format(Locale.ROOT,
                         "Unable to find datasource '%s' for Jimmer: %s",
@@ -60,13 +52,6 @@ public class JimmerDataSourcesRecorder {
             DataSource dataSource;
             try {
                 dataSource = context.getInjectedReference(DataSources.class).getDataSource(dataSourceName);
-                if (dataSource instanceof UnconfiguredDataSource) {
-                    throw new ConfigurationException(String.format(Locale.ROOT,
-                            "Datasource '%s' is not configured."
-                                    + " To solve this, configure datasource '%s'."
-                                    + " Refer to https://quarkus.io/guides/datasource for guidance.",
-                            dataSourceName, dataSourceName));
-                }
             } catch (ConfigurationException e) {
                 return new UnConfiguredDataSourceQuarkusKSqlClientContainer(dataSourceName, String.format(Locale.ROOT,
                         "Unable to find datasource '%s' for Jimmer: %s",

--- a/runtime/src/main/java/io/quarkiverse/jimmer/runtime/cloud/QuarkusExchange.java
+++ b/runtime/src/main/java/io/quarkiverse/jimmer/runtime/cloud/QuarkusExchange.java
@@ -33,7 +33,7 @@ public class QuarkusExchange implements MicroServiceExchange {
 
     @Override
     public List<ImmutableSpi> findByIds(String microServiceName, Collection<?> ids, Fetcher<?> fetcher) throws Exception {
-        RestClientsConfig.RestClientConfig restClientConfig = restClientsConfig.getClient(microServiceName);
+        RestClientsConfig.RestClientConfig restClientConfig = restClientsConfig.clients().get(microServiceName);
         if (restClientConfig.url().isPresent()) {
             ExchangeRestClient quarkusExchangeRestClient = QuarkusRestClientBuilder.newBuilder()
                     .baseUrl(URI.create(restClientConfig.url().get()).toURL()).build(ExchangeRestClient.class);
@@ -51,7 +51,7 @@ public class QuarkusExchange implements MicroServiceExchange {
     @Override
     public List<Tuple2<Object, ImmutableSpi>> findByAssociatedIds(String microServiceName, ImmutableProp prop,
             Collection<?> targetIds, Fetcher<?> fetcher) throws Exception {
-        RestClientsConfig.RestClientConfig restClientConfig = restClientsConfig.getClient(microServiceName);
+        RestClientsConfig.RestClientConfig restClientConfig = restClientsConfig.clients().get(microServiceName);
         if (restClientConfig.url().isPresent()) {
             ExchangeRestClient quarkusExchangeRestClient = QuarkusRestClientBuilder.newBuilder()
                     .baseUrl(URI.create(restClientConfig.url().get()).toURL()).build(ExchangeRestClient.class);


### PR DESCRIPTION
Hey! I'm using quarkus-jimmer in my project with Quarkus 3.32.3 and hit some runtime errors. `UnconfiguredDataSource` class is gone and `RestClientsConfig.getClient()` changed its signature. Decided to fix it and share.

## What's changed

- **Quarkus** `3.15.0` -> `3.32.3`
- **Kotlin** `2.1.0` -> `2.3.20`

## Details

- Removed `UnconfiguredDataSource` instanceof checks. The class was removed in Quarkus 3.32, but `DataSources.getDataSource()` now throws `ConfigurationException` on its own, so the existing catch block covers it
- Switched `RestClientsConfig.getClient(String)` to `clients().get(String)` since the method now accepts `Class<?>` instead of `String`